### PR TITLE
Use a better green for 1-5 commits

### DIFF
--- a/repo-contrib-graph
+++ b/repo-contrib-graph
@@ -14,7 +14,7 @@ set_vars() {
   DAYS[6]='S'
   if [ -n "$use_color" ]; then
     HEAT_1=$'\e[38;5;102m'
-    HEAT_2=$'\e[38;5;46m'
+    HEAT_2=$'\e[38;5;34m'
     HEAT_3=$'\e[38;5;28m'
     HEAT_4=$'\e[38;5;22m'
     ENDC=$'\e[0m'


### PR DESCRIPTION
This green isn't as saturated. The old green was very bright and was misleading. It felt like it indicated more commits

### Before

![image](https://cloud.githubusercontent.com/assets/519171/20722259/e0c04038-b633-11e6-9bea-d9b98484b3d9.png)

### After

![image](https://cloud.githubusercontent.com/assets/519171/20722285/f0399e6a-b633-11e6-9968-1c3cca4e2335.png)
