### PR TITLE
Update to HTTP/2 and add parameter shifting after getopts

### DIFF
--- a/repo-contrib-graph
+++ b/repo-contrib-graph
@@ -186,7 +186,7 @@ while getopts r:t:cphd option; do
   d)  DEBUG=true
   esac
 done
-
+shift $((OPTIND-1))
 repo=$1
 
 if [ -z "$repo" ]; then

--- a/repo-contrib-graph
+++ b/repo-contrib-graph
@@ -53,7 +53,7 @@ prime_endpoint()
   local res=202
   printf "Starting..."
   while [[ $res != 200 ]]; do
-    res=$(curl -s -L -I ${AUTH_STRING:+-H "$AUTH_STRING"} -w %{http_code} $ENDPOINT | grep HTTP/1.1 | awk {'print $2'})
+    res=$(curl -s -L -I ${AUTH_STRING:+-H "$AUTH_STRING"} -w %{http_code} $ENDPOINT | grep HTTP/2 | awk {'print $2'})
     printf "."
     sleep 1
     if [[ $res != 20? ]]; then


### PR DESCRIPTION
Hello!

I tried to use your project today but I found two things that needed to be fixed to allow it to work:

1. GitHub API now uses HTTP/2 so checking the return code would fail when greping HTTP/1.1
2. Parameters need to be shifted after getopts in order to get the correct repo name